### PR TITLE
PaytmLabs Docker Build to Github Packages

### DIFF
--- a/exporter-go/Dockerfile
+++ b/exporter-go/Dockerfile
@@ -4,5 +4,6 @@ COPY . .
 RUN GOOS=linux CGO_ENABLED=0 GOARCH=amd64 go build .
 # Now copy it into our base image.
 FROM gcr.io/distroless/static
+LABEL org.opencontainers.image.source=https://github.com/PaytmLabs/opa-scorecard
 COPY --from=build /app/opa_scorecard_exporter /app/opa_scorecard_exporter
 CMD ["/app/opa_scorecard_exporter","--incluster=true"]

--- a/exporter-go/build_docker.sh
+++ b/exporter-go/build_docker.sh
@@ -4,4 +4,7 @@ IMAGE=${1:-paytmlabs/opa_scorecard_exporter:v0.0.4-labs-0.0.1}
 
 
 docker build --tag="${IMAGE}" .
+
+# Push will fail unless docker is logged in to a Github account with write access to the Packages repo
+# See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry
 docker push "${IMAGE}"

--- a/exporter-go/build_docker.sh
+++ b/exporter-go/build_docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE=${1:-paytmlabs/opa_scorecard_exporter:v0.0.4-labs-0.0.1}
+IMAGE=${1:-ghcr.io/paytmlabs/opa_scorecard_exporter:v0.0.4-labs-0.0.1}
 
 
 docker build --tag="${IMAGE}" .

--- a/exporter-go/build_docker.sh
+++ b/exporter-go/build_docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE=${1:-mcelep/opa_scorecard_exporter:v0.0.3}
+IMAGE=${1:-paytmlabs/opa_scorecard_exporter:v0.0.4-labs-0.0.1}
 
 
 docker build --tag="${IMAGE}" .


### PR DESCRIPTION
Quick public Docker image build to Github Packages

Following the upstream's style for a simple scripted build. Images can be pushed by contributors with write access to this repo.

If our public fork becomes more than a one-off, this should be redone with Github Actions to automate releases.